### PR TITLE
Change spy_glass to citygram-services in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ TODO
 * [Install Ruby](https://github.com/codeforamerica/howto/blob/master/Ruby.md)
 
 ```
-git clone https://github.com/citygram/spy_glass.git
-cd spy_glass
+git clone https://github.com/citygram/citygram-services.git
+cd citygram-services
 cp .env.sample .env
 gem install bundler
 bundle install


### PR DESCRIPTION
Assuming this is necessary considering the changed repo name... correct me if I'm wrong.
