### PR TITLE
Registry for NYC 311 Dataset

### DIFF
--- a/lib/spy_glass/registry/nyc-311.rb
+++ b/lib/spy_glass/registry/nyc-311.rb
@@ -1,0 +1,44 @@
+require 'spy_glass/registry'
+
+time_zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+opts = {
+  path: '/nyc-311',
+  cache: SpyGlass::Cache::Memory.new(expires_in: 300),
+  source: 'http://data.cityofnewyork.us/resource/erm2-nwe9.json?'+Rack::Utils.build_query({
+    '$limit' => 1000,
+    '$order' => 'created_date DESC',
+    '$where' => <<-WHERE.oneline
+      created_date >= '#{7.days.ago.iso8601}' AND
+      longitude IS NOT NULL AND
+      latitude IS NOT NULL AND
+      unique_key IS NOT NULL
+    WHERE
+  })
+}
+
+SpyGlass::Registry << SpyGlass::Client::Socrata.new(opts) do |collection|
+  features = collection.map do |item|
+    time = Time.iso8601(item['created_date']).in_time_zone(time_zone)
+    title =  <<-TITLE.oneline
+ A new 311 case has been opened at #{item['incident_address']} in #{item['city']}.
+      The complaint type is #{item['complaint_type'].downcase} - #{item['descriptor']} and the assigned agency is #{item['agency']}
+    TITLE
+
+    {
+      'id' => item['unique_key'],
+      'type' => 'Feature',
+      'geometry' => {
+        'type' => 'Point',
+        'coordinates' => [
+          item['longitude'].to_f,
+          item['latitude'].to_f
+        ]
+      },
+      'properties' => item.merge('title' => title)
+    }
+  end
+
+  {'type' => 'FeatureCollection', 'features' => features}
+end
+


### PR DESCRIPTION
Created a registry for NYC 311

Issues:

-NYC 311 pushes about 30,000 new records once per day, so a 1000 row API call won't cut it.
-Complaints can be for an address or an intersection.  Need some logic to determine which is which so the right fields are used in the title
